### PR TITLE
Apply aws updates

### DIFF
--- a/deepracer/logs/log_utils.py
+++ b/deepracer/logs/log_utils.py
@@ -639,6 +639,21 @@ class PlottingUtils:
         plt.clf()
 
     @staticmethod
+    def plot_trackpoints(track: Track):
+        fig, ax = plt.subplots(figsize=(20, 10))
+        PlottingUtils.plot_points(ax, track.center_line)
+        PlottingUtils.plot_points(ax, track.inner_border)
+        PlottingUtils.plot_points(ax, track.outer_border)
+        ax.axis('equal')
+        plt.show()
+
+    @staticmethod
+    def plot_points(ax, points):
+        ax.scatter(points[:-1, 0], points[:-1, 1], s=1)
+        for i, p in enumerate(points):
+            ax.annotate(i, (p[0], p[1]))
+
+    @staticmethod
     def _plot_coords(ax, ob):
         x, y = ob.xy
         ax.plot(x, y, '.', color='#999999', zorder=1)

--- a/deepracer/logs/log_utils.py
+++ b/deepracer/logs/log_utils.py
@@ -124,8 +124,8 @@ class SimulationLogsIO:
             parts = d.rstrip().split(",")
             episode = int(parts[0])
             steps = int(parts[1])
-            x = 100 * float(parts[2])
-            y = 100 * float(parts[3])
+            x = float(parts[2])
+            y = float(parts[3])
             yaw = float(parts[4])
             steer = float(parts[5])
             throttle = float(parts[6])
@@ -552,7 +552,7 @@ class PlottingUtils:
         episode_df.loc[:, 'distance_diff'] = ((episode_df['x'].shift(1) - episode_df['x']) ** 2 + (
             episode_df['y'].shift(1) - episode_df['y']) ** 2) ** 0.5
 
-        distance = np.nansum(episode_df['distance_diff']) / 100
+        distance = np.nansum(episode_df['distance_diff'])
         lap_time = np.ptp(episode_df['timestamp'].astype(float))
         velocity = distance / lap_time
         average_throttle = np.nanmean(episode_df['throttle'])
@@ -598,10 +598,10 @@ class PlottingUtils:
                 plt.clf()
 
     @staticmethod
-    def plot_track(df, track: Track, value_field="reward", margin=100):
+    def plot_track(df, track: Track, value_field="reward", margin=1):
         """Plot track with dots presenting the rewards for steps
         """
-        track_size = (np.asarray(track.size()) + 2*margin).astype(int)
+        track_size = (np.asarray(track.size()) + 2*margin).astype(int) * 100
         track_img = np.zeros(track_size).transpose()
 
         x_coord = 0
@@ -612,8 +612,8 @@ class PlottingUtils:
         y_compensation = df['y'].min()
 
         for index, row in df.iterrows():
-            x = int(row["x"] - x_compensation + margin)
-            y = int(row["y"] - y_compensation + margin)
+            x = int((row["x"] - x_compensation + margin) * 100)
+            y = int((row["y"] - y_compensation + margin) * 100)
 
             # clip values that are off track
             if y >= track_size[y_coord]:
@@ -627,8 +627,8 @@ class PlottingUtils:
         fig = plt.figure(1, figsize=(12, 16))
         ax = fig.add_subplot(111)
 
-        shifted_track = Track("shifted_track", (track.waypoints * 100 -
-                                                [x_compensation, y_compensation]*3 + margin) / 100.)
+        shifted_track = Track("shifted_track", (track.waypoints -
+                                                [x_compensation, y_compensation]*3 + margin) * 100)
 
         PlottingUtils.print_border(ax, shifted_track)
 
@@ -793,21 +793,21 @@ class NewRewardUtils:
             )
 
         params = {
-            'x': df_row['x'] / 100,
-            'y': df_row['y'] / 100,
+            'x': df_row['x'],
+            'y': df_row['y'],
             'speed': df_row['throttle'],
             'steps': df_row['steps'],
             'progress': df_row['progress'],
             'heading': df_row['yaw'] * 180 / 3.14,
             'closest_waypoints': closest_waypoints,
             'steering_angle': df_row['steer'] * 180 / 3.14,
-            'waypoints': waypoints / 100,
+            'waypoints': waypoints,
             'distance_from_center':
                 gu.get_vector_length(
                     (
                         closest_point -
                         current_location
-                    ) / 100),
+                    )),
             'timestamp': df_row['timestamp'],
             # TODO I didn't need them yet. DOIT
             'track_width': 0.60,
@@ -922,7 +922,7 @@ class ActionBreakdownUtils:
                 if track_breakdown:
                     for idWp in track_breakdown.vert_lines:
                         ax.text(wpts_array[idWp][0],
-                                wpts_array[idWp][1] + 20,
+                                wpts_array[idWp][1] + 0.2,
                                 str(idWp),
                                 bbox=dict(facecolor='red', alpha=0.5))
 

--- a/deepracer/tracks/track_utils.py
+++ b/deepracer/tracks/track_utils.py
@@ -152,9 +152,9 @@ class Track:
     Fields:
     name - name of the track loaded
     waypoints - input list as received by constructor
-    center_line - waypoints along the center of the track with coordinates in centimeters
-    inner_border - waypoints along the inner border of the track with coordinates in centimeters
-    outer_border - waypoints along the outer border of the track with coordinates in centimeters
+    center_line - waypoints along the center of the track with coordinates in meters
+    inner_border - waypoints along the inner border of the track with coordinates in meters
+    outer_border - waypoints along the outer border of the track with coordinates in meters
     road_poly - a polygon representing the track
     """
 
@@ -167,9 +167,9 @@ class Track:
         """
         self.name = name
         self.waypoints = waypoints
-        self.center_line = waypoints[:, 0:2] * 100
-        self.inner_border = waypoints[:, 2:4] * 100
-        self.outer_border = waypoints[:, 4:6] * 100
+        self.center_line = waypoints[:, 0:2]
+        self.inner_border = waypoints[:, 2:4]
+        self.outer_border = waypoints[:, 4:6]
 
         l_inner_border = LineString(waypoints[:, 2:4])
         l_outer_border = LineString(waypoints[:, 4:6])

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setup(
         # Pick your license as you wish
         'License :: OSI Approved :: Apache Software License',
 
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
@@ -34,7 +33,7 @@ setup(
         'Topic :: Internet :: Log Analysis'
     ],
     keywords='aws deepracer awsdeepracer',
-    python_requires='>=3.5.*, <4',
+    python_requires='>=3.6.*, <4',
     install_requires=[
         'boto3>=1.12.0',
         'python-dateutil<3.0.0,>=2.1',


### PR DESCRIPTION
I ended up performing three changes:
* increase the lower boundary for python to 3.6 to match that of pandas 1.0.1
* add plotting of track waypoints (taken from AWS log analysis)
* change waypoint coordinates units from meters to centimeters (taken from AWS log analysis) - except for the reward heatmap where changing to meters breaks the graph, making the background have 10,000 fewer pixels

I have decided to refrain from using logs stored in S3 as it feels more complicated than fetching them from CloudWatch. I will not include it until I see a good reason.
There were also some potentially interesting changes in the part of notebook involving models but this requires a whole separate chunk of work to be ported.