### PR TITLE
A workaround for an excess comma in logs

### DIFF
--- a/deepracer/logs/log.py
+++ b/deepracer/logs/log.py
@@ -36,6 +36,27 @@ class DeepRacerLog:
             "episode_status",
             "pause_duration"
         ]
+        # TODO Column names as a workaround for an excess comma in the CSV file
+        self.col_names_workaround = [
+            "episode",
+            "steps",
+            "x",
+            "y",
+            "heading",
+            "steering_angle",
+            "speed",
+            "action",
+            "action_b",
+            "reward",
+            "done",
+            "all_wheels_on_track",
+            "progress",
+            "closest_waypoint",
+            "track_len",
+            "tstamp",
+            "episode_status",
+            "pause_duration"
+        ]
         self.hyperparam_keys = [
             "batch_size",
             "beta_entropy",
@@ -73,10 +94,15 @@ class DeepRacerLog:
 
         def read_csv(path):
             try:
-                df = pd.read_csv(path, names=self.col_names, header=0)
-            except pd.errors.ParserError as e:
-                # Older logs don't have pause_duration, so we're handling this
-                df = pd.read_csv(path, names=self.col_names[:-1], header=0)
+                # TODO: this is a workaround and should be removed when logs are fixed
+                df = pd.read_csv(path, names=self.col_names_workaround, header=0)
+                df.drop("action_b")
+            except pd.errors.ParserError:
+                try:
+                    df = pd.read_csv(path, names=self.col_names, header=0)
+                except pd.errors.ParserError:
+                    # Older logs don't have pause_duration, so we're handling this
+                    df = pd.read_csv(path, names=self.col_names[:-1], header=0)
 
             df["iteration"] = int(path.split(os.path.sep)[-1].split("-")[0])
             df["worker"] = int(path.split(os.path.sep)[-3] if self.type ==

--- a/deepracer/logs/log_utils.py
+++ b/deepracer/logs/log_utils.py
@@ -121,6 +121,10 @@ class SimulationLogsIO:
         # ignore the first two dummy values that coach throws at the start.
         for d in data[2:]:
             parts = d.rstrip().split(",")
+            # TODO: this is a workaround and should be removed when logs are fixed
+            parts_workaround = 0
+            if len(parts) > 17:
+                parts_workaround = 1
             episode = int(parts[0])
             steps = int(parts[1])
             x = float(parts[2])
@@ -132,16 +136,16 @@ class SimulationLogsIO:
                 action = int(parts[7])
             except ValueError as e:
                 action = -1
-            reward = float(parts[8])
-            done = 0 if 'False' in parts[9] else 1
-            all_wheels_on_track = parts[10]
-            progress = float(parts[11])
-            closest_waypoint = int(parts[12])
-            track_len = float(parts[13])
-            tstamp = Decimal(parts[14])
-            episode_status = parts[15]
-            if len(parts) > 16:
-                pause_duration = float(parts[16])
+            reward = float(parts[8+parts_workaround])
+            done = 0 if 'False' in parts[9+parts_workaround] else 1
+            all_wheels_on_track = parts[10+parts_workaround]
+            progress = float(parts[11+parts_workaround])
+            closest_waypoint = int(parts[12+parts_workaround])
+            track_len = float(parts[13+parts_workaround])
+            tstamp = Decimal(parts[14+parts_workaround])
+            episode_status = parts[15+parts_workaround]
+            if len(parts) > 16+parts_workaround:
+                pause_duration = float(parts[16+parts_workaround])
             else:
                 pause_duration = 0.0
 


### PR DESCRIPTION
Now for continuous action there is a comma in the action value which makes csv and regular logs think there's an addition column and it messes up the log loading. This workaround should fix it. Clean up after it's fixed