### PR TITLE
Issues/45

### DIFF
--- a/deepracer/logs/log_utils.py
+++ b/deepracer/logs/log_utils.py
@@ -711,8 +711,9 @@ class PlottingUtils:
                 track_img[y, x] = row[value_field]
             except:
                 error_coords.append((x,y))
-     
-        logging.warning(f'An error was thrown when trying to calculate coordinates: {",".join("(%s,%s)" % tup for tup in error_coords)}')
+
+        if len(error_coords) > 0:
+            logging.warning(f'An error was thrown when trying to calculate coordinates: {",".join("(%s,%s)" % tup for tup in error_coords)}')
 
         fig = plt.figure(1, figsize=(12, 16))
         ax = fig.add_subplot(111)

--- a/deepracer/logs/log_utils.py
+++ b/deepracer/logs/log_utils.py
@@ -693,6 +693,9 @@ class PlottingUtils:
         x_compensation = track.outer_border[:, 0].min()
         y_compensation = track.outer_border[:, 1].min()
 
+        ## The coordinates that were out of range and an error was thrown
+        error_coords=[]
+
         for _, row in df.iterrows():
             x = int((row["x"] - x_compensation + margin) * 100)
             y = int((row["y"] - y_compensation + margin) * 100)
@@ -704,7 +707,12 @@ class PlottingUtils:
             if x >= track_size[x_coord]:
                 x = track_size[x_coord] - 1
 
-            track_img[y, x] = row[value_field]
+            try:
+                track_img[y, x] = row[value_field]
+            except:
+                error_coords.append((x,y))
+     
+        logging.warning(f'An error was thrown when trying to calculate coordinates: {",".join("(%s,%s)" % tup for tup in error_coords)}')
 
         fig = plt.figure(1, figsize=(12, 16))
         ax = fig.add_subplot(111)

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -7,7 +7,7 @@ In the lastest version of Deepracer Utils the foundation class to use is `DeepRa
 
 ### Local
 
-The basic example covers a model directory, either downloaded from the console or stored in a minio folder, and where the training simtrace files, the `model_metadata.json` and `hyperparameters.json` files are available.
+The basic example covers a model director downloaded from the console ~~or stored in a minio folder~~, and where the training simtrace files, the `model_metadata.json` and `hyperparameters.json` files are available.
 
 ```
 from deepracer.logs import (AnalysisUtils, DeepRacerLog)


### PR DESCRIPTION
BUGFIX: For Github issue 45
    For error being thrown when index of x or y coordinates outside of bound of the track.
    
    - Add a try catch for these cases that saves the error coordinates
    - Prints a warning of all coordinates that threw an error during calculation
    - Does not break execution.