### PR TITLE
Aligned licenses

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-Copyright 2019-2020 AWS DeepRacer Community. All Rights Reserved.
+Copyright 2019-2023 AWS DeepRacer Community. All Rights Reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this
 software and associated documentation files (the "Software"), to deal in the Software

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         'Development Status :: 5 - Production/Stable',
 
         # Pick your license as you wish
-        'License :: OSI Approved :: Apache Software License',
+        'License :: OSI Approved :: MIT No Attribution License (MIT-0)',
 
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',


### PR DESCRIPTION
There was a discrepancy between Apache and MIT-0 license. Aligned to MIT-0 in setup.py as well.