### PR TITLE
fixing column names while parsing deepracer log dataframe for new reward

### DIFF
--- a/deepracer/logs/log_utils.py
+++ b/deepracer/logs/log_utils.py
@@ -870,7 +870,7 @@ class NewRewardUtils:
             'speed': df_row['speed'],
             'steps': df_row['steps'],
             'progress': df_row['progress'],
-            'heading': df_row['yaw'] * 180 / 3.14,
+            'heading': df_row['heading'] * 180 / 3.14, #changing yaw to heading as DeepRacerLog class load with column name heading
             'closest_waypoints': closest_waypoints,
             'steering_angle': df_row['steering_angle'] * 180 / 3.14,
             'waypoints': waypoints,


### PR DESCRIPTION
This fix helps to use deepracer log analysis Notebooks to use new_reward effectively.

Earlier the new_reward load was failing due to incorrect column names on Dataframe.

DeepRacerLog class in log.py is loading the logs using 'heading' name instead of 'yaw'.