### PR TITLE
Reduce dependency complexity

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
 [project.optional-dependencies]
 visualization = [
     "tensorflow>=2.10.0",
-    "opencv-python",
+    "opencv-python-headless",
     "Pillow",
 ]
 dev = [


### PR DESCRIPTION
This pull request makes a small update to the visualization dependencies in `pyproject.toml`. The change replaces `opencv-python` with `opencv-python-headless` to avoid unnecessary GUI dependencies and improve compatibility in headless environments.